### PR TITLE
fix: migrate to geoportal.emtvalencia.es

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python package to query EMT Valencia (bus).
 
 ![](https://raw.githubusercontent.com/andoniaf/pyemtvlc/master/img/pyemtvlc_logo_small.png)
 
-Information obtained from [EMT Valencia](http://movil.emtvalencia.es).
+Information obtained from [EMT Valencia](https://geoportal.emtvalencia.es).
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -9,24 +9,26 @@ Information obtained from [EMT Valencia](https://geoportal.emtvalencia.es).
 
 # Examples
 
-- Info about all lines of the bus stop. (636):
+- Info about all lines of the bus stop. (1054):
 ```
-➜ pyemtvlc 636  
-Parada: 636
-7: Pl. Espanya - 7 min.
-13: Pta.de la Mar - 8 min.
-7: Pl. Espanya - 25 min.
-13: Pta.de la Mar - 44 min.
-N7: Pl. Ajuntament - 22:38
-N7: Pl. Ajuntament - 23:03
+➜ pyemtvlc 1054
+Parada: 1054
+C2 Av. Arago - 7 min.
+10 Benimaclet - 7 min.
+10 Benimaclet - 16 min.
+12 C.Art.Faller - 16 min.
+93 Pass. Marítim - 18 min.
+C2 Av. Arago - 20 min.
+93 Pass. Marítim - 23 min.
+12 C.Art.Faller - 29 min.
 ```
 
-- Info about one line (7) of the bus stop (636):
+- Info about one line (12) of the bus stop (1054):
 ```
- ➜ pyemtvlc 636 7
-Parada: 636
-7: Pl. Espanya - 22 min.
-7: Pl. Espanya - 46 min.
+➜ pyemtvlc 1054 12
+Parada: 1054
+12 C.Art.Faller - 16 min.
+12 C.Art.Faller - 29 min.
 ```
 
 ------

--- a/pyemtvlc
+++ b/pyemtvlc
@@ -4,16 +4,8 @@ from utils.parser import next_buses
 
 
 def main():
-    # Display deprecation message
-    print("\n*** DEPRECATED ***")
-    print("This tool has been deprecated because EMT Valencia took down the mobile website")
-    print("that was used to parse the bus information.")
-    print("The original functionality is preserved below but will not work correctly.")
-    print("***************\n")
-    
     if len(sys.argv) == 1:
         msg = "Uso:\n   pyemtvlc <Número Parada> <Linea (Opcional)>\n"
-        # msg += "   pyemtvlc -s <Número Tarjeta>"
     else:
         numParada = sys.argv[1]
         if not numParada.isdigit():
@@ -24,9 +16,7 @@ def main():
             if len(sys.argv) > 2:
                 numLinea = numLinea + sys.argv[2]
                 numLinea = numLinea.lower()
-            # Override the next_buses call to return the deprecation message
-            # msg = next_buses(numParada, numLinea)
-            msg = "DEPRECATED: EMT Valencia took down the mobile website used to parse the information."
+            msg = next_buses(numParada, numLinea)
     print(msg)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests==2.22.0
-beautifulsoup4==4.8.0
+requests

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='pyemtvlc',
-    version='0.3.6',
+    version='1.0.0',
     scripts=['pyemtvlc'],
     author="Andoni Alonso F.",
     author_email="andonialonsof@gmail.com",
@@ -15,7 +15,7 @@ setuptools.setup(
     url="https://github.com/andoniaf/pyemtvlc",
     packages=setuptools.find_packages(),
     install_requires=[
-        'requests', 'beautifulsoup4'
+        'requests'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,6 +1,6 @@
+import xml.etree.ElementTree as ET
 from unittest import TestCase
-from utils.parser import generate_msg, parse_soup
-from bs4 import BeautifulSoup as bs
+from utils.parser import generate_msg, parse_xml
 
 
 class TestParser(TestCase):
@@ -16,10 +16,49 @@ class TestParser(TestCase):
         expected = 'Sin estimaciones. ¿Seguro que esta linea pasa por esta parada?'
         self.assertEqual(expected, msg)
 
-    def test_soup_parse(self):
-        fake_res = \
-            '[<span class="imagenParada"><img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/></span>, <img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/>, <span class="llegadaHome">  Pl. Espanya - 6 min.</span>, <br/>, <span class="imagenParada"><img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/></span>, <img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/>, <span class="llegadaHome">  Pl. Espanya - 10 min.</span>, <br/>]'
-        soup = bs(fake_res, "html.parser")
-        info = parse_soup(soup)
+    def test_xml_parse(self):
+        fake_xml = """<?xml version='1.0' encoding='UTF-8'?>
+<estimacion parada="636">
+  <solo_parada>
+    <bus>
+      <linea>9</linea>
+      <destino>Pl. Espanya</destino>
+      <minutos>6 min.</minutos>
+      <horaLlegada/>
+      <error/>
+    </bus>
+    <bus>
+      <linea>9</linea>
+      <destino>Pl. Espanya</destino>
+      <minutos>10 min.</minutos>
+      <horaLlegada/>
+      <error/>
+    </bus>
+  </solo_parada>
+  <parada_linea/>
+  <info/>
+</estimacion>"""
+        root = ET.fromstring(fake_xml)
+        info = parse_xml(root)
         expected = [['9', 'Pl. Espanya - 6 min.'], ['9', 'Pl. Espanya - 10 min.']]
+        self.assertEqual(expected, info)
+
+    def test_xml_parse_horallegada(self):
+        fake_xml = """<?xml version='1.0' encoding='UTF-8'?>
+<estimacion parada="636">
+  <solo_parada>
+    <bus>
+      <linea>N7</linea>
+      <destino>Pl. Ajuntament</destino>
+      <minutos/>
+      <horaLlegada>22:38</horaLlegada>
+      <error/>
+    </bus>
+  </solo_parada>
+  <parada_linea/>
+  <info/>
+</estimacion>"""
+        root = ET.fromstring(fake_xml)
+        info = parse_xml(root)
+        expected = [['N7', 'Pl. Ajuntament - 22:38']]
         self.assertEqual(expected, info)

--- a/test/test_parser_mock.py
+++ b/test/test_parser_mock.py
@@ -1,27 +1,55 @@
 from unittest import TestCase
 from utils.parser import next_buses
 import responses
+from utils.emtinfo import EMT_URL
 
 
 class TestParserMock(TestCase):
     @responses.activate
     def test_sin_estimaciones(self):
-        fake_data = \
-            '<img align="left" src="modules/mod_tiempo/img/icono peligro.jpg"/><span class="llegadaHome">SIN ESTIMACIONES</span>'
-        responses.add(responses.POST, 'http://movil.emtvalencia.es/mod_tiempo/busca_parada.php',
-                      body=fake_data, status=200,
-                      content_type='application/x-www-form-urlencoded')
+        fake_data = """<?xml version='1.0' encoding='UTF-8'?>
+<estimacion parada="19321">
+  <solo_parada>
+    <bus>
+      <linea>9</linea>
+      <destino>Pl. Espanya</destino>
+      <minutos/>
+      <horaLlegada/>
+      <error>SIN ESTIMACIONES</error>
+    </bus>
+  </solo_parada>
+  <parada_linea/>
+  <info/>
+</estimacion>"""
+        responses.add(responses.GET, EMT_URL, body=fake_data, status=200)
         info = next_buses("19321")
         expected = 'Sin estimaciones. ¿Seguro que esta linea pasa por esta parada?'
         self.assertEqual(expected, info)
 
     @responses.activate
     def test_next_buses(self):
-        fake_data = \
-            '<span class="imagenParada"><img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/></span>, <img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/>, <span class="llegadaHome">  Pl. Espanya - 6 min.</span>, <br/>, <span class="imagenParada"><img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/></span>, <img height="25px" src="http://www.emtvalencia.es/EmtEsquemas_graphics/line-icons/9bigW.gif" title="9" width="25px"/>, <span class="llegadaHome">  Pl. Espanya - 10 min.</span>, <br/>'
-        responses.add(responses.POST, 'http://movil.emtvalencia.es/mod_tiempo/busca_parada.php',
-                      body=fake_data, status=200,
-                      content_type='application/x-www-form-urlencoded')
+        fake_data = """<?xml version='1.0' encoding='UTF-8'?>
+<estimacion parada="1932">
+  <solo_parada>
+    <bus>
+      <linea>9</linea>
+      <destino>Pl. Espanya</destino>
+      <minutos>6 min.</minutos>
+      <horaLlegada/>
+      <error/>
+    </bus>
+    <bus>
+      <linea>9</linea>
+      <destino>Pl. Espanya</destino>
+      <minutos>10 min.</minutos>
+      <horaLlegada/>
+      <error/>
+    </bus>
+  </solo_parada>
+  <parada_linea/>
+  <info/>
+</estimacion>"""
+        responses.add(responses.GET, EMT_URL, body=fake_data, status=200)
         info = next_buses("1932", "9")
         expected = '9 Pl. Espanya - 6 min.\n9 Pl. Espanya - 10 min.\n'
         self.assertEqual(expected, info)

--- a/test/test_parser_mock.py
+++ b/test/test_parser_mock.py
@@ -21,7 +21,7 @@ class TestParserMock(TestCase):
   <parada_linea/>
   <info/>
 </estimacion>"""
-        responses.add(responses.GET, EMT_URL, body=fake_data, status=200)
+        responses.add(responses.GET, EMT_URL, body=fake_data.encode('utf-8'), status=200)
         info = next_buses("19321")
         expected = 'Sin estimaciones. ¿Seguro que esta linea pasa por esta parada?'
         self.assertEqual(expected, info)
@@ -49,7 +49,7 @@ class TestParserMock(TestCase):
   <parada_linea/>
   <info/>
 </estimacion>"""
-        responses.add(responses.GET, EMT_URL, body=fake_data, status=200)
+        responses.add(responses.GET, EMT_URL, body=fake_data.encode('utf-8'), status=200)
         info = next_buses("1932", "9")
         expected = '9 Pl. Espanya - 6 min.\n9 Pl. Espanya - 10 min.\n'
         self.assertEqual(expected, info)

--- a/utils/emtinfo.py
+++ b/utils/emtinfo.py
@@ -1,32 +1,24 @@
 import requests
 
+EMT_URL = 'https://geoportal.emtvalencia.es/EMT/mapfunctions/MapUtilsPetitions.php'
+
+_headers = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36',
+    'Accept': 'application/json, text/plain, */*',
+    'Accept-Language': 'es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3',
+    'Referer': 'https://geoportal.emtvalencia.es/visor?lang=es',
+    'Connection': 'keep-alive',
+}
+
 
 def get_info(numParada, numLinea=''):
-    cookies = {
-        '__utma': '25540009.1894639261.1539253515.1550245270.1552753595.4',
-        '__utmz': '25540009.1552753595.4.3.utmcsr=google|utmccn=(organic)|utmcmd=organic|utmctr=(not%20provided)',
-        '__utmb': '25540009.4.10.1552753595',
-        '__utmc': '25540009',
-        'PHPSESSID': 'aj1va5hon0r7uuhiqehrogco96',
-        'nombreparada': numParada,
-    }
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:65.0) Gecko/20100101 Firefox/65.0',
-        'Accept': '*/*',
-        'Accept-Language': 'es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3',
-        'Referer': 'http://movil.emtvalencia.es/index.php?op=pl',
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Connection': 'keep-alive',
-        'Pragma': 'no-cache',
-        'Cache-Control': 'no-cache',
-    }
-    data = {
+    params = {
+        'sec': 'getSAE',
         'parada': numParada,
-        'adaptados': '0',
-        'usuario': 'movilemt',
-        'linea': numLinea,
-        'idioma': 'es'
+        'adaptados': 'false',
+        'idioma': 'es',
     }
-    emt_url = 'http://movil.emtvalencia.es/mod_tiempo/busca_parada.php'
-    res = requests.post(emt_url, headers=headers, cookies=cookies, data=data)
+    if numLinea:
+        params['linea'] = numLinea
+    res = requests.get(EMT_URL, headers=_headers, params=params)
     return res

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -1,31 +1,40 @@
-from bs4 import BeautifulSoup as bs
+import xml.etree.ElementTree as ET
 import utils.emtinfo as emtinfo
 
 
-# Create 'soup' object
-def generate_soup(numParada, numLinea=''):
-    # Get raw info from emt web
+def get_xml(numParada, numLinea=''):
     raw_data = emtinfo.get_info(numParada, numLinea)
-    soup = bs(raw_data.text, "html.parser")
-    return soup
+    return ET.fromstring(raw_data.text)
 
 
-# Parse soup object to extract info
-def parse_soup(soup):
-    # If EMT know nothing, we are John Snow too...
-    if not soup.text:
+def parse_xml(root):
+    # root tag is <estimacion>, buses are inside <solo_parada> or <parada_linea>
+    container = root.find('solo_parada')
+    if container is None:
+        container = root.find('parada_linea')
+    if container is None:
         return [[None, '']]
-    # data is inside spans
-    spanTimeData = soup.find_all('span', {'class': 'llegadaHome'})
-    # img tag contain line num
-    imgElem = soup.select('img')
+
+    buses = container.findall('bus')
+    if not buses:
+        return [[None, '']]
+
     info = []
-    for span, img in zip(spanTimeData, imgElem):
-        linea = img.get('title')
-        time = span.getText(strip=True)
-        busTime = [linea, time]
-        info.append(busTime)
-    return info
+    for bus in buses:
+        linea = bus.findtext('linea', '').strip()
+        destino = bus.findtext('destino', '').strip()
+        minutos = bus.findtext('minutos', '').strip()
+        hora = bus.findtext('horaLlegada', '').strip()
+        error = bus.findtext('error', '').strip()
+
+        if error:
+            info.append([None, error])
+            continue
+
+        time = hora if not minutos else minutos
+        info.append([linea, destino + ' - ' + time])
+
+    return info if info else [[None, '']]
 
 
 def error_output(inMsg):
@@ -35,16 +44,12 @@ def error_output(inMsg):
         'Temporalmente no disponible. Actualiza la estimación en unos segundos.': 'La parada no existe o esta temporalmente no disponible',
         '': 'La parada no existe o esta temporalmente no disponible'
     }
-    output = error_msg.get(inMsg, "ERROR")
-    return output
+    return error_msg.get(inMsg, "ERROR")
 
 
-# Generate msg with parsed info or errors
 def generate_msg(info):
     output = ''
-    # Check if no data
     if info[0][0] is None:
-        # Get error_msg
         output = error_output(info[0][1])
     else:
         for row in info:
@@ -53,6 +58,6 @@ def generate_msg(info):
 
 
 def next_buses(numParada, numLinea=''):
-    soup_obj = generate_soup(numParada, numLinea.upper())
-    info = parse_soup(soup_obj)
+    root = get_xml(numParada, numLinea.upper())
+    info = parse_xml(root)
     return generate_msg(info)

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -4,7 +4,7 @@ import utils.emtinfo as emtinfo
 
 def get_xml(numParada, numLinea=''):
     raw_data = emtinfo.get_info(numParada, numLinea)
-    return ET.fromstring(raw_data.text)
+    return ET.fromstring(raw_data.content)
 
 
 def parse_xml(root):


### PR DESCRIPTION
## Summary

- Migrates endpoint from defunct `movil.emtvalencia.es` to `geoportal.emtvalencia.es`
- Rewrites parser from BeautifulSoup HTML scraping to `xml.etree.ElementTree` (new endpoint returns XML)
- Fixes UTF-8 encoding issue (`Próximo` displaying as `PrÃ³ximo`) by passing raw bytes to the XML parser
- Drops `beautifulsoup4` dependency (no longer needed)
- Bumps version to `1.0.0`
- Updates README examples to use stop 1054

## Test plan

- [ ] Run unit/mock tests: `.venv/bin/pytest test/test_parser.py test/test_parser_mock.py -v`
- [ ] Smoke test against live API: `.venv/bin/python3 pyemtvlc 1054`
- [ ] Test with specific line: `.venv/bin/python3 pyemtvlc 1054 12`